### PR TITLE
python 3 fix in dnn.py

### DIFF
--- a/theano/sandbox/cuda/dnn.py
+++ b/theano/sandbox/cuda/dnn.py
@@ -278,7 +278,7 @@ class GpuDnnConvDesc(GpuOp):
         nb_dim = len(self.subsample)
 
         if isinstance(self.border_mode, tuple):
-            pad_desc = map(int, self.border_mode)
+            pad_desc = tuple(map(int, self.border_mode))
             assert min(pad_desc) >= 0
             bmode = 2
         else:


### PR DESCRIPTION
In python 3, map returns a map object iterator rather than a list, which here gets consumed by min, leaving pad_desc empty.
This bug was just introduced with the update to cudnn v3.